### PR TITLE
More styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ else's stolen property.
 * CoffeeScript
 * PostgreSQL (via Interactive Ruby Shell)
 * Active Record 
+* Bootstrap
+* Font Awesome Icons
+* Material UI library and framework
 
 ## Team Members
 
@@ -48,6 +51,18 @@ To be added
 
 ## Approach Taken
 
-To be added
+We decided early-on to build an app that had a unique niche of dedicated users. Most importantly, we focused 
+on creating a service that we would use and was relevant. Seattle is a bike-centric city, which unfortunately also
+makes it a target for bicycles thieves. After reading about Bike Batman, the Seattle vigilante who scours Craigslist 
+ads for stolen bikes being flipped for a quick buck, we settled on a registry that could help the recover and prevent 
+bike-related crimes.
+
+Whiteboarding wireframes/ERD diagrams and clearly outlining our CRUD functionality kept the project organized and 
+merge conflicts minimal, as everyone had a clearly delegated job. We separated components into self-contained partials 
+which allowed group members to tackle features displayed on the same page. 
+
+Keeping organized with a clear vision of our minimum viable product allowed us to quickly and efficiently dial in our 
+required features and move on to the fun stuff. We had time to try our hands at Cloudinary image uploads, interactive 
+jQuery forms Nokogiri data scraping, SVG/CSS animations, and a hand-coded search function.
 
 ## 

--- a/app/assets/stylesheets/bike.css
+++ b/app/assets/stylesheets/bike.css
@@ -136,6 +136,20 @@ transform: skewY(20deg);
     text-align: center;
 }
 
+.page-heading {
+    text-transform: uppercase;
+    padding-top: 15px;
+    padding-bottom: 20px;
+}
+
+/* Styles for forms */
+
+.form-section {
+    width: 50%;
+    padding-bottom: 30px;
+
+}
+
 /* Styles for user profile page */
 
 .user-bikes {

--- a/app/assets/stylesheets/bike.css
+++ b/app/assets/stylesheets/bike.css
@@ -139,7 +139,7 @@ transform: skewY(20deg);
 /* Styles for user profile page */
 
 .user-bikes {
-    border: 2px solid #66CCFF;
+    /*border: 2px solid #66CCFF;*/
     padding: 10px;
     margin: 20px;
     border-radius: 5px;

--- a/app/views/bike/edit.html.erb
+++ b/app/views/bike/edit.html.erb
@@ -9,74 +9,96 @@
             <div class="mui-textfield ">
                 <%= form.label :brand %>
                 <%= form.text_field :brand %>
-                </div></div></div>
-<br><br>
-<%= form.label :model %>
-<%= form.text_field :model %>
-<br><br>
-<%= form.label :serialnumber %>
-<br>
-<%= form.text_field :serial_num %>
+                </div>
+        </div>
 
+        <div class="col-md-6">
+            <div class="mui-textfield">
+                <%= form.label :model %>
+                <%= form.text_field :model %>
+            </div>
+        </div>
+    </div>
 
-<br><br>
-<br><br>
-<%= form.label :Primarycolor %>
-<%= form.select :color_primary, [['Red','red'],
-                                ['Dark Red', 'dark red'],
-                                ['Light Red', 'light red'],
-                                ['Blue','blue'],
-                                ['Dark Blue','dark blue'],
-                                ['Light Blue','light blue'],
-                                ['Green','green'],
-                                ['Dark Green','dark green'],
-                                ['Light Green','light green'],
-                                ['Yellow','yellow'],
-                                ['Orange','orange'],
-                                ['White','white'],
-                                ['Black', 'black'],
-                                ['Grey','grey'],
-                                ['Purple','purple']] %>
+    <div class="row">
+        <div class="col-md-12">
+            <div class="mui-textfield">
+                <%= form.text_field :serial_num %>
+                <%= form.label :serial_number %>
+            </div>
+        </div>
+    </div>
 
+    <div class="row">
+        <div class="col-md-4">
+            <div class="mui-select">
+                <%= form.label :Primary_color %>
+                <%= form.select :color_primary, [
+                ['None', 'none'],
+                ['Red','red'],
+                ['Dark Red', 'dark red'],
+                ['Light Red', 'light red'],
+                ['Blue','blue'],
+                ['Dark Blue','dark blue'],
+                ['Light Blue','light blue'],
+                ['Green','green'],
+                ['Dark Green','dark green'],
+                ['Light Green','light green'],
+                ['Yellow','yellow'],
+                ['Orange','orange'],
+                ['White','white'],
+                ['Black', 'black'],
+                ['Grey','grey'],
+                ['Purple','purple']] %>
+            </div>
+        </div>
 
+        <div class="col-md-4">
+            <div class="mui-select">
+                <%= form.label :Secondary_color %>
+                <%= form.select :color_secondary, [
+                ['None', 'none'],
+                ['Red','red'],
+                ['Dark Red', 'dark red'],
+                ['Light Red', 'light red'],
+                ['Blue','blue'],
+                ['Dark Blue','dark blue'],
+                ['Light Blue','light blue'],
+                ['Green','green'],
+                ['Dark Green','dark green'],
+                ['Light Green','light green'],
+                ['Yellow','yellow'],
+                ['Orange','orange'],
+                ['White','white'],
+                ['Black', 'black'],
+                ['Grey','grey'],
+                ['Purple','purple']] %>
+            </div>
+        </div>
 
-<br><br>
-<%= form.label :Secondcolor %>
-<%= form.select :color_secondary, [['Red','red'],
-                                ['Dark Red', 'dark red'],
-                                ['Light Red', 'light red'],
-                                ['Blue','blue'],
-                                ['Dark Blue','dark blue'],
-                                ['Light Blue','light blue'],
-                                ['Green','green'],
-                                ['Dark Green','dark green'],
-                                ['Light Green','light green'],
-                                ['Yellow','yellow'],
-                                ['Orange','orange'],
-                                ['White','white'],
-                                ['Black', 'black'],
-                                ['Grey','grey'],
-                                ['Purple','purple']] %>
-
-<br><br>
-<%= form.label :Thirdcolor %>
-<%= form.select :color_tertiary, [['Red','red'],
-                                ['Dark Red', 'dark red'],
-                                ['Light Red', 'light red'],
-                                ['Blue','blue'],
-                                ['Dark Blue','dark blue'],
-                                ['Light Blue','light blue'],
-                                ['Green','green'],
-                                ['Dark Green','dark green'],
-                                ['Light Green','light green'],
-                                ['Yellow','yellow'],
-                                ['Orange','orange'],
-                                ['White','white'],
-                                ['Black', 'black'],
-                                ['Grey','grey'],
-                                ['Purple','purple']] %>
-
-
+        <div class="col-md-4">
+            <div class="mui-select">
+                <%= form.label :Tertiary_color %>
+                <%= form.select :color_tertiary, [
+                ['None', 'none'],
+                ['Red','red'],
+                ['Dark Red', 'dark red'],
+                ['Light Red', 'light red'],
+                ['Blue','blue'],
+                ['Dark Blue','dark blue'],
+                ['Light Blue','light blue'],
+                ['Green','green'],
+                ['Dark Green','dark green'],
+                ['Light Green','light green'],
+                ['Yellow','yellow'],
+                ['Orange','orange'],
+                ['White','white'],
+                ['Black', 'black'],
+                ['Grey','grey'],
+                ['Purple','purple']] %>
+            </div>
+        </div>
+    </div>
 
 
 <br><br>

--- a/app/views/bike/edit.html.erb
+++ b/app/views/bike/edit.html.erb
@@ -2,7 +2,10 @@
 
     <%= form_for @bike do |form| %>
 
-    <h1>Edit bike info</h1>
+    <h1>Edit</h1>
+
+    <hr>
+    <h3>Information</h3>
 
     <div class="row">
         <div class="col-md-6">
@@ -28,6 +31,9 @@
             </div>
         </div>
     </div>
+
+    <hr>
+    <h3>Appearance</h3>
 
     <div class="row">
         <div class="col-md-4">
@@ -101,25 +107,65 @@
     </div>
 
 
-<br><br>
-<%= form.radio_button(:is_stolen, true) %>
-<%= form.label(:bike_true, "My bike was stolen") %>
-<%= form.radio_button(:is_stolen, false) %>
-<%= form.label(:bike_false, "My bike was not stolen") %>
+    <div class="row">
+        <div class="col-md-12">
+            <div class="mui-textfield">
+                <%= form.text_area :description, class: '', id: 'description', placeholder: 'Has a Georgetown Brewing Company sticker on downtube, scratch on front fork, pink tassles on handlebars. Was locked up at 3rd and University bike rack when Kryptonite U-lock was snipped between 1pm and 3pm.' %>
+                <%= form.label :description, class: '', for: 'description' %>
+            </div>
+        </div>
+    </div>
 
+    <div class="row">
+        <div class="col-md-12">
+            <div class="mui-textfield">
+                <%= form.label :photo %>
+                <%= form.file_field :photo, class: 'mui-btn' %>
+            </div>
+        </div>
+    </div>
 
-<span class="photoInput">
-  <br><br>
-  <%= form.label :photo %>
-  <%= form.file_field :photo %>
-</span>
+    <hr>
+    <h3>Missing Status</h3>
 
-<br><br>
-<%= form.label :description %>
-<br>
-<%= form.text_area :description %>
-<br><br>
-<%= form.submit %>
-<%end%>
+    <div class="row" id="stolen-section">
+        <div class="col-md-6" style="padding-left: 70px;">
+            <div class="mui-textfield">
+                <div class="row mui-radio" style="position: absolute; top: 0; display: block; width: 100%; color: rgba(0,0,0,.54); font-size: 12px; font-weight: 400; line-height: 15px; overflow-x: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                    <%= form.radio_button(:is_stolen, true, {:class => "true_clicked" }) %>
+                    <%= form.label(:bike_true, "My bike was stolen") %>
+                </div>
+                <div class="row mui-radio" style="position: absolute; top: 0; display: block; width: 100%; color: rgba(0,0,0,.54); font-size: 12px; font-weight: 400; line-height: 15px; overflow-x: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                    <%= form.radio_button(:is_stolen, false, {:class => "false_clicked"}) %>
+                    <%= form.label(:bike_false, "My bike was not stolen", class: '', for: 'is_stolen') %>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-6">
+            <div class="stolen_form" style="display: none">
+
+                <div class="row">
+                    <div class="mui-textfield">
+                        <%= form.text_field :stolen_zip, class: '', id: 'stolen_zip' %>
+                        <%= form.label :stolen_zip %>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="mui-textfield">
+                        <%= form.text_field :stolen_date, class: '', id: 'stolen_date', placeholder: '01/01/16' %>
+                        <%= form.label :stolen_date %>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row" style="text-align: center; padding-top: 50px;">
+        <%= form.submit 'Register', :class => 'mui-btn mui-btn--primary' %>
+    </div>
+
+    <%end%>
 
 </div>

--- a/app/views/bike/edit.html.erb
+++ b/app/views/bike/edit.html.erb
@@ -1,11 +1,15 @@
-<div class="bikeForm">
-  
-<h1>Edit bike info</h1>
+<div class="bikeForm container well">
 
+    <%= form_for @bike do |form| %>
 
-<%= form_for @bike do |form| %>
-<%= form.label :brand %>
-<%= form.text_field :brand %>
+    <h1>Edit bike info</h1>
+
+    <div class="row">
+        <div class="col-md-6">
+            <div class="mui-textfield ">
+                <%= form.label :brand %>
+                <%= form.text_field :brand %>
+                </div></div></div>
 <br><br>
 <%= form.label :model %>
 <%= form.text_field :model %>

--- a/app/views/bike/edit.html.erb
+++ b/app/views/bike/edit.html.erb
@@ -1,161 +1,166 @@
-<div class="bikeForm container well">
+<div class="bikeForm container">
 
     <%= form_for @bike do |form| %>
 
-    <h1>Edit</h1>
+    <div class="page-heading mui--text-light mui--text-display1">Edit a bike</div>
 
-    <hr>
-    <h3>Information</h3>
-
-    <div class="row">
-        <div class="col-md-6">
-            <div class="mui-textfield ">
-                <%= form.label :brand %>
-                <%= form.text_field :brand %>
+    <div class="form-section panel container">
+        <h3>Information</h3>
+        <div class="row">
+            <div class="col-md-6">
+                <div class="mui-textfield ">
+                    <%= form.label :brand %>
+                    <%= form.text_field :brand %>
                 </div>
-        </div>
-
-        <div class="col-md-6">
-            <div class="mui-textfield">
-                <%= form.label :model %>
-                <%= form.text_field :model %>
             </div>
-        </div>
-    </div>
 
-    <div class="row">
-        <div class="col-md-12">
-            <div class="mui-textfield">
-                <%= form.text_field :serial_num %>
-                <%= form.label :serial_number %>
-            </div>
-        </div>
-    </div>
-
-    <hr>
-    <h3>Appearance</h3>
-
-    <div class="row">
-        <div class="col-md-4">
-            <div class="mui-select">
-                <%= form.label :Primary_color %>
-                <%= form.select :color_primary, [
-                ['None', 'none'],
-                ['Red','red'],
-                ['Dark Red', 'dark red'],
-                ['Light Red', 'light red'],
-                ['Blue','blue'],
-                ['Dark Blue','dark blue'],
-                ['Light Blue','light blue'],
-                ['Green','green'],
-                ['Dark Green','dark green'],
-                ['Light Green','light green'],
-                ['Yellow','yellow'],
-                ['Orange','orange'],
-                ['White','white'],
-                ['Black', 'black'],
-                ['Grey','grey'],
-                ['Purple','purple']] %>
-            </div>
-        </div>
-
-        <div class="col-md-4">
-            <div class="mui-select">
-                <%= form.label :Secondary_color %>
-                <%= form.select :color_secondary, [
-                ['None', 'none'],
-                ['Red','red'],
-                ['Dark Red', 'dark red'],
-                ['Light Red', 'light red'],
-                ['Blue','blue'],
-                ['Dark Blue','dark blue'],
-                ['Light Blue','light blue'],
-                ['Green','green'],
-                ['Dark Green','dark green'],
-                ['Light Green','light green'],
-                ['Yellow','yellow'],
-                ['Orange','orange'],
-                ['White','white'],
-                ['Black', 'black'],
-                ['Grey','grey'],
-                ['Purple','purple']] %>
-            </div>
-        </div>
-
-        <div class="col-md-4">
-            <div class="mui-select">
-                <%= form.label :Tertiary_color %>
-                <%= form.select :color_tertiary, [
-                ['None', 'none'],
-                ['Red','red'],
-                ['Dark Red', 'dark red'],
-                ['Light Red', 'light red'],
-                ['Blue','blue'],
-                ['Dark Blue','dark blue'],
-                ['Light Blue','light blue'],
-                ['Green','green'],
-                ['Dark Green','dark green'],
-                ['Light Green','light green'],
-                ['Yellow','yellow'],
-                ['Orange','orange'],
-                ['White','white'],
-                ['Black', 'black'],
-                ['Grey','grey'],
-                ['Purple','purple']] %>
-            </div>
-        </div>
-    </div>
-
-
-    <div class="row">
-        <div class="col-md-12">
-            <div class="mui-textfield">
-                <%= form.text_area :description, class: '', id: 'description', placeholder: 'Has a Georgetown Brewing Company sticker on downtube, scratch on front fork, pink tassles on handlebars. Was locked up at 3rd and University bike rack when Kryptonite U-lock was snipped between 1pm and 3pm.' %>
-                <%= form.label :description, class: '', for: 'description' %>
-            </div>
-        </div>
-    </div>
-
-    <div class="row">
-        <div class="col-md-12">
-            <div class="mui-textfield">
-                <%= form.label :photo %>
-                <%= form.file_field :photo, class: 'mui-btn' %>
-            </div>
-        </div>
-    </div>
-
-    <hr>
-    <h3>Missing Status</h3>
-
-    <div class="row" id="stolen-section">
-        <div class="col-md-6" style="padding-left: 70px;">
-            <div class="mui-textfield">
-                <div class="row mui-radio" style="position: absolute; top: 0; display: block; width: 100%; color: rgba(0,0,0,.54); font-size: 12px; font-weight: 400; line-height: 15px; overflow-x: hidden; text-overflow: ellipsis; white-space: nowrap;">
-                    <%= form.radio_button(:is_stolen, true, {:class => "true_clicked" }) %>
-                    <%= form.label(:bike_true, "My bike was stolen") %>
-                </div>
-                <div class="row mui-radio" style="position: absolute; top: 0; display: block; width: 100%; color: rgba(0,0,0,.54); font-size: 12px; font-weight: 400; line-height: 15px; overflow-x: hidden; text-overflow: ellipsis; white-space: nowrap;">
-                    <%= form.radio_button(:is_stolen, false, {:class => "false_clicked"}) %>
-                    <%= form.label(:bike_false, "My bike was not stolen", class: '', for: 'is_stolen') %>
+            <div class="col-md-6">
+                <div class="mui-textfield">
+                    <%= form.label :model %>
+                    <%= form.text_field :model %>
                 </div>
             </div>
         </div>
 
-        <div class="col-md-6">
-            <div class="stolen_form" style="display: none">
+        <div class="row">
+            <div class="col-md-12">
+                <div class="mui-textfield">
+                    <%= form.text_field :serial_num %>
+                    <%= form.label :serial_number %>
+                </div>
+            </div>
+        </div>
+    </div>
 
-                <div class="row">
-                    <div class="mui-textfield">
-                        <%= form.text_field :stolen_zip, class: '', id: 'stolen_zip' %>
-                        <%= form.label :stolen_zip %>
+    <div class="form-section panel container">
+        <h3>Appearance</h3>
+
+        <div class="row">
+            <div class="col-md-4">
+                <div class="mui-select">
+                    <%= form.label :Primary_color %>
+                    <%= form.select :color_primary, [
+                    ['None', 'none'],
+                    ['Red','red'],
+                    ['Dark Red', 'dark red'],
+                    ['Light Red', 'light red'],
+                    ['Blue','blue'],
+                    ['Dark Blue','dark blue'],
+                    ['Light Blue','light blue'],
+                    ['Green','green'],
+                    ['Dark Green','dark green'],
+                    ['Light Green','light green'],
+                    ['Yellow','yellow'],
+                    ['Orange','orange'],
+                    ['White','white'],
+                    ['Black', 'black'],
+                    ['Grey','grey'],
+                    ['Purple','purple']] %>
+                </div>
+            </div>
+
+            <div class="col-md-4">
+                <div class="mui-select">
+                    <%= form.label :Secondary_color %>
+                    <%= form.select :color_secondary, [
+                    ['None', 'none'],
+                    ['Red','red'],
+                    ['Dark Red', 'dark red'],
+                    ['Light Red', 'light red'],
+                    ['Blue','blue'],
+                    ['Dark Blue','dark blue'],
+                    ['Light Blue','light blue'],
+                    ['Green','green'],
+                    ['Dark Green','dark green'],
+                    ['Light Green','light green'],
+                    ['Yellow','yellow'],
+                    ['Orange','orange'],
+                    ['White','white'],
+                    ['Black', 'black'],
+                    ['Grey','grey'],
+                    ['Purple','purple']] %>
+                </div>
+            </div>
+
+            <div class="col-md-4">
+                <div class="mui-select">
+                    <%= form.label :Tertiary_color %>
+                    <%= form.select :color_tertiary, [
+                    ['None', 'none'],
+                    ['Red','red'],
+                    ['Dark Red', 'dark red'],
+                    ['Light Red', 'light red'],
+                    ['Blue','blue'],
+                    ['Dark Blue','dark blue'],
+                    ['Light Blue','light blue'],
+                    ['Green','green'],
+                    ['Dark Green','dark green'],
+                    ['Light Green','light green'],
+                    ['Yellow','yellow'],
+                    ['Orange','orange'],
+                    ['White','white'],
+                    ['Black', 'black'],
+                    ['Grey','grey'],
+                    ['Purple','purple']] %>
+                </div>
+            </div>
+        </div>
+
+
+        <div class="row">
+            <div class="col-md-12">
+                <div class="mui-textfield">
+                    <%= form.text_area :description, class: '', id: 'description', placeholder: 'Has a Georgetown
+                    Brewing Company sticker on downtube, scratch on front fork, pink tassles on handlebars. Was locked
+                    up at 3rd and University bike rack when Kryptonite U-lock was snipped between 1pm and 3pm.' %>
+                    <%= form.label :description, class: '', for: 'description' %>
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-12">
+                <div class="mui-textfield">
+                    <%= form.label :photo %>
+                    <%= form.file_field :photo, class: 'mui-btn' %>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="form-section panel container">
+        <h3>Missing Status</h3>
+
+        <div class="row" id="stolen-section">
+            <div class="col-md-6" style="padding-left: 70px;">
+                <div class="mui-textfield">
+                    <div class="row mui-radio"
+                         style="position: absolute; top: 0; display: block; width: 100%; color: rgba(0,0,0,.54); font-size: 12px; font-weight: 400; line-height: 15px; overflow-x: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                        <%= form.radio_button(:is_stolen, true, {:class => "true_clicked" }) %>
+                        <%= form.label(:bike_true, "My bike was stolen") %>
+                    </div>
+                    <div class="row mui-radio"
+                         style="position: absolute; top: 0; display: block; width: 100%; color: rgba(0,0,0,.54); font-size: 12px; font-weight: 400; line-height: 15px; overflow-x: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                        <%= form.radio_button(:is_stolen, false, {:class => "false_clicked"}) %>
+                        <%= form.label(:bike_false, "My bike was not stolen", class: '', for: 'is_stolen') %>
                     </div>
                 </div>
+            </div>
 
-                <div class="row">
-                    <div class="mui-textfield">
-                        <%= form.text_field :stolen_date, class: '', id: 'stolen_date', placeholder: '01/01/16' %>
-                        <%= form.label :stolen_date %>
+            <div class="col-md-6">
+                <div class="stolen_form" style="display: none">
+
+                    <div class="row">
+                        <div class="mui-textfield">
+                            <%= form.text_field :stolen_zip, class: '', id: 'stolen_zip' %>
+                            <%= form.label :stolen_zip %>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="mui-textfield">
+                            <%= form.text_field :stolen_date, class: '', id: 'stolen_date', placeholder: '01/01/16' %>
+                            <%= form.label :stolen_date %>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/app/views/bike/index.html.erb
+++ b/app/views/bike/index.html.erb
@@ -7,14 +7,14 @@
     <div class="row">
         <div class="col-md-6">
             <div class="mui-textfield">
-                <%= form.text_field :brand, class: 'form-control', id: 'brand' %>
+                <%= form.text_field :brand, class: '', id: 'brand' %>
                 <%= form.label :brand, class: '', for: 'brand' %>
             </div>
         </div>
 
         <div class="col-md-6">
             <div class="mui-textfield">
-                <%= form.text_field :model, class: 'form-control', id: 'model' %>
+                <%= form.text_field :model, class: '', id: 'model' %>
                 <%= form.label :model, class: '', for: 'model' %>
             </div>
         </div>
@@ -23,7 +23,7 @@
     <div class="row">
         <div class="col-md-12">
             <div class="mui-textfield">
-                <%= form.text_field :serial_num, class: 'form-control', id: 'serial_num' %>
+                <%= form.text_field :serial_num, class: '', id: 'serial_num' %>
                 <%= form.label :serial_number, class: '', for: 'serial_num' %>
             </div>
         </div>
@@ -112,7 +112,7 @@
     <div class="row">
         <div class="col-md-12">
             <div class="mui-textfield">
-                <%= form.text_area :description, class: 'form-control', id: 'description', placeholder: 'Has a Georgetown Brewing Company sticker on downtube, scratch on front fork, pink tassles on handlebars. Was locked up at 3rd and University bike rack when Kryptonite U-lock was snipped between 1pm and 3pm.' %>
+                <%= form.text_area :description, class: '', id: 'description', placeholder: 'Has a Georgetown Brewing Company sticker on downtube, scratch on front fork, pink tassles on handlebars. Was locked up at 3rd and University bike rack when Kryptonite U-lock was snipped between 1pm and 3pm.' %>
                 <%= form.label :description, class: '', for: 'description' %>
             </div>
         </div>
@@ -137,14 +137,14 @@
 
                 <div class="row">
                     <div class="mui-textfield">
-                        <%= form.text_field :stolen_zip, class: 'form-control', id: 'stolen_zip' %>
+                        <%= form.text_field :stolen_zip, class: '', id: 'stolen_zip' %>
                         <%= form.label :stolen_zip %>
                     </div>
                 </div>
 
                 <div class="row">
                     <div class="mui-textfield">
-                        <%= form.text_field :stolen_date, class: 'form-control', id: 'stolen_date', placeholder: '01/01/16' %>
+                        <%= form.text_field :stolen_date, class: '', id: 'stolen_date', placeholder: '01/01/16' %>
                         <%= form.label :stolen_date %>
                     </div>
                 </div>

--- a/app/views/bike/index.html.erb
+++ b/app/views/bike/index.html.erb
@@ -1,74 +1,79 @@
-<div class="bikeForm">
+<div class="bikeForm container well">
 
     <h1>Add a bike</h1>
 
     <%= form_for :bike do |form| %>
-    <%= form.label :brand %>
-    <%= form.text_field :brand %>
-    <br><br>
-    <%= form.label :model %>
-    <%= form.text_field :model %>
-    <br><br>
-    <%= form.label :serialnumber %>
-    <br>
-    <%= form.text_field :serial_num %>
 
+    <div class="md-form">
+        <%= form.text_field :brand, class: 'form-control', id: 'brand' %>
+        <%= form.label :brand, class: '', for: 'brand' %>
+    </div>
+
+    <div class="md-form">
+        <%= form.text_field :model, class: 'form-control', id: 'model' %>
+        <%= form.label :model, class: '', for: 'model' %>
+    </div>
+
+    <div class="md-form">
+        <%= form.text_field :serial_num, class: 'form-control', id: 'serial_num' %>
+        <%= form.label :serial_num, class: '', for: 'serial_num' %>
+    </div>
 
     <br><br>
     <%= form.label :Primarycolor %>
     <%= form.select :color_primary, [['Red','red'],
-                                ['Dark Red', 'dark red'],
-                                ['Light Red', 'light red'],
-                                ['Blue','blue'],
-                                ['Dark Blue','dark blue'],
-                                ['Light Blue','light blue'],
-                                ['Green','green'],
-                                ['Dark Green','dark green'],
-                                ['Light Green','light green'],
-                                ['Yellow','yellow'],
-                                ['Orange','orange'],
-                                ['White','white'],
-                                ['Black', 'black'],
-                                ['Grey','grey'],
-                                ['Purple','purple']] %>
+    ['Dark Red', 'dark red'],
+    ['Light Red', 'light red'],
+    ['Blue','blue'],
+    ['Dark Blue','dark blue'],
+    ['Light Blue','light blue'],
+    ['Green','green'],
+    ['Dark Green','dark green'],
+    ['Light Green','light green'],
+    ['Yellow','yellow'],
+    ['Orange','orange'],
+    ['White','white'],
+    ['Black', 'black'],
+    ['Grey','grey'],
+    ['Purple','purple']] %>
 
 
 
     <br><br>
     <%= form.label :Secondcolor %>
     <%= form.select :color_secondary, [['Red','red'],
-                                ['Dark Red', 'dark red'],
-                                ['Light Red', 'light red'],
-                                ['Blue','blue'],
-                                ['Dark Blue','dark blue'],
-                                ['Light Blue','light blue'],
-                                ['Green','green'],
-                                ['Dark Green','dark green'],
-                                ['Light Green','light green'],
-                                ['Yellow','yellow'],
-                                ['Orange','orange'],
-                                ['White','white'],
-                                ['Black', 'black'],
-                                ['Grey','grey'],
-                                ['Purple','purple']] %>
+    ['Dark Red', 'dark red'],
+    ['Light Red', 'light red'],
+    ['Blue','blue'],
+    ['Dark Blue','dark blue'],
+    ['Light Blue','light blue'],
+    ['Green','green'],
+    ['Dark Green','dark green'],
+    ['Light Green','light green'],
+    ['Yellow','yellow'],
+    ['Orange','orange'],
+    ['White','white'],
+    ['Black', 'black'],
+    ['Grey','grey'],
+    ['Purple','purple']] %>
 
     <br><br>
     <%= form.label :Thirdcolor %>
     <%= form.select :color_tertiary, [['Red','red'],
-                                ['Dark Red', 'dark red'],
-                                ['Light Red', 'light red'],
-                                ['Blue','blue'],
-                                ['Dark Blue','dark blue'],
-                                ['Light Blue','light blue'],
-                                ['Green','green'],
-                                ['Dark Green','dark green'],
-                                ['Light Green','light green'],
-                                ['Yellow','yellow'],
-                                ['Orange','orange'],
-                                ['White','white'],
-                                ['Black', 'black'],
-                                ['Grey','grey'],
-                                ['Purple','purple']] %>
+    ['Dark Red', 'dark red'],
+    ['Light Red', 'light red'],
+    ['Blue','blue'],
+    ['Dark Blue','dark blue'],
+    ['Light Blue','light blue'],
+    ['Green','green'],
+    ['Dark Green','dark green'],
+    ['Light Green','light green'],
+    ['Yellow','yellow'],
+    ['Orange','orange'],
+    ['White','white'],
+    ['Black', 'black'],
+    ['Grey','grey'],
+    ['Purple','purple']] %>
 
 
 

--- a/app/views/bike/index.html.erb
+++ b/app/views/bike/index.html.erb
@@ -4,6 +4,9 @@
 
     <h1>Add a bike</h1>
 
+    <hr>
+    <h3>Information</h3>
+
     <div class="row">
         <div class="col-md-6">
             <div class="mui-textfield">
@@ -28,6 +31,9 @@
             </div>
         </div>
     </div>
+
+    <hr>
+    <h3>Appearance</h3>
 
     <div class="row">
         <div class="col-md-4">
@@ -103,8 +109,8 @@
     <div class="row">
         <div class="col-md-12">
             <div class="mui-textfield">
-                <%= form.label :photo %>
-                <%= form.file_field :photo, class: 'mui-btn' %>
+                <%= form.text_area :description, class: '', id: 'description', placeholder: 'Has a Georgetown Brewing Company sticker on downtube, scratch on front fork, pink tassles on handlebars. Was locked up at 3rd and University bike rack when Kryptonite U-lock was snipped between 1pm and 3pm.' %>
+                <%= form.label :description, class: '', for: 'description' %>
             </div>
         </div>
     </div>
@@ -112,11 +118,15 @@
     <div class="row">
         <div class="col-md-12">
             <div class="mui-textfield">
-                <%= form.text_area :description, class: '', id: 'description', placeholder: 'Has a Georgetown Brewing Company sticker on downtube, scratch on front fork, pink tassles on handlebars. Was locked up at 3rd and University bike rack when Kryptonite U-lock was snipped between 1pm and 3pm.' %>
-                <%= form.label :description, class: '', for: 'description' %>
+                <%= form.label :photo %>
+                <%= form.file_field :photo, class: 'mui-btn' %>
             </div>
         </div>
     </div>
+
+
+    <hr>
+    <h3>Missing Status</h3>
 
     <div class="row" id="stolen-section">
         <div class="col-md-6" style="padding-left: 70px;">
@@ -148,10 +158,8 @@
                         <%= form.label :stolen_date %>
                     </div>
                 </div>
-
             </div>
         </div>
-
     </div>
 
     <div class="row" style="text-align: center; padding-top: 50px;">

--- a/app/views/bike/index.html.erb
+++ b/app/views/bike/index.html.erb
@@ -1,161 +1,165 @@
-<div class="bikeForm container well">
+<div class="bikeForm container">
 
     <%= form_for :bike do |form| %>
 
-    <h1>Add a bike</h1>
+    <div class="page-heading mui--text-light mui--text-display1">Add a bike</div>
 
-    <hr>
-    <h3>Information</h3>
+    <div class="form-section panel container">
+        <h3>Information</h3>
 
-    <div class="row">
-        <div class="col-md-6">
-            <div class="mui-textfield">
-                <%= form.text_field :brand, class: '', id: 'brand' %>
-                <%= form.label :brand, class: '', for: 'brand' %>
-            </div>
-        </div>
-
-        <div class="col-md-6">
-            <div class="mui-textfield">
-                <%= form.text_field :model, class: '', id: 'model' %>
-                <%= form.label :model, class: '', for: 'model' %>
-            </div>
-        </div>
-    </div>
-
-    <div class="row">
-        <div class="col-md-12">
-            <div class="mui-textfield">
-                <%= form.text_field :serial_num, class: '', id: 'serial_num' %>
-                <%= form.label :serial_number, class: '', for: 'serial_num' %>
-            </div>
-        </div>
-    </div>
-
-    <hr>
-    <h3>Appearance</h3>
-
-    <div class="row">
-        <div class="col-md-4">
-            <div class="mui-select">
-                <%= form.label :Primary_color %>
-                <%= form.select :color_primary, [
-                ['None', 'none'],
-                ['Red','red'],
-                ['Dark Red', 'dark red'],
-                ['Light Red', 'light red'],
-                ['Blue','blue'],
-                ['Dark Blue','dark blue'],
-                ['Light Blue','light blue'],
-                ['Green','green'],
-                ['Dark Green','dark green'],
-                ['Light Green','light green'],
-                ['Yellow','yellow'],
-                ['Orange','orange'],
-                ['White','white'],
-                ['Black', 'black'],
-                ['Grey','grey'],
-                ['Purple','purple']] %>
-            </div>
-        </div>
-
-        <div class="col-md-4">
-            <div class="mui-select">
-                <%= form.label :Secondary_color %>
-                <%= form.select :color_secondary, [
-                ['None', 'none'],
-                ['Red','red'],
-                ['Dark Red', 'dark red'],
-                ['Light Red', 'light red'],
-                ['Blue','blue'],
-                ['Dark Blue','dark blue'],
-                ['Light Blue','light blue'],
-                ['Green','green'],
-                ['Dark Green','dark green'],
-                ['Light Green','light green'],
-                ['Yellow','yellow'],
-                ['Orange','orange'],
-                ['White','white'],
-                ['Black', 'black'],
-                ['Grey','grey'],
-                ['Purple','purple']] %>
-            </div>
-        </div>
-
-        <div class="col-md-4">
-            <div class="mui-select">
-                <%= form.label :Tertiary_color %>
-                <%= form.select :color_tertiary, [
-                ['None', 'none'],
-                ['Red','red'],
-                ['Dark Red', 'dark red'],
-                ['Light Red', 'light red'],
-                ['Blue','blue'],
-                ['Dark Blue','dark blue'],
-                ['Light Blue','light blue'],
-                ['Green','green'],
-                ['Dark Green','dark green'],
-                ['Light Green','light green'],
-                ['Yellow','yellow'],
-                ['Orange','orange'],
-                ['White','white'],
-                ['Black', 'black'],
-                ['Grey','grey'],
-                ['Purple','purple']] %>
-            </div>
-        </div>
-    </div>
-
-    <div class="row">
-        <div class="col-md-12">
-            <div class="mui-textfield">
-                <%= form.text_area :description, class: '', id: 'description', placeholder: 'Has a Georgetown Brewing Company sticker on downtube, scratch on front fork, pink tassles on handlebars. Was locked up at 3rd and University bike rack when Kryptonite U-lock was snipped between 1pm and 3pm.' %>
-                <%= form.label :description, class: '', for: 'description' %>
-            </div>
-        </div>
-    </div>
-
-    <div class="row">
-        <div class="col-md-12">
-            <div class="mui-textfield">
-                <%= form.label :photo %>
-                <%= form.file_field :photo, class: 'mui-btn' %>
-            </div>
-        </div>
-    </div>
-
-
-    <hr>
-    <h3>Missing Status</h3>
-
-    <div class="row" id="stolen-section">
-        <div class="col-md-6" style="padding-left: 70px;">
-            <div class="mui-textfield">
-                <div class="row mui-radio" style="position: absolute; top: 0; display: block; width: 100%; color: rgba(0,0,0,.54); font-size: 12px; font-weight: 400; line-height: 15px; overflow-x: hidden; text-overflow: ellipsis; white-space: nowrap;">
-                    <%= form.radio_button(:is_stolen, true, {:class => "true_clicked" }) %>
-                    <%= form.label(:bike_true, "My bike was stolen") %>
+        <div class="row">
+            <div class="col-md-6">
+                <div class="mui-textfield">
+                    <%= form.text_field :brand, class: '', id: 'brand' %>
+                    <%= form.label :brand, class: '', for: 'brand' %>
                 </div>
-                <div class="row mui-radio" style="position: absolute; top: 0; display: block; width: 100%; color: rgba(0,0,0,.54); font-size: 12px; font-weight: 400; line-height: 15px; overflow-x: hidden; text-overflow: ellipsis; white-space: nowrap;">
-                    <%= form.radio_button(:is_stolen, false, {:class => "false_clicked"}) %>
-                    <%= form.label(:bike_false, "My bike was not stolen", class: '', for: 'is_stolen') %>
+            </div>
+
+            <div class="col-md-6">
+                <div class="mui-textfield">
+                    <%= form.text_field :model, class: '', id: 'model' %>
+                    <%= form.label :model, class: '', for: 'model' %>
                 </div>
             </div>
         </div>
 
-        <div class="col-md-6">
-            <div class="stolen_form" style="display: none">
+        <div class="row">
+            <div class="col-md-12">
+                <div class="mui-textfield">
+                    <%= form.text_field :serial_num, class: '', id: 'serial_num' %>
+                    <%= form.label :serial_number, class: '', for: 'serial_num' %>
+                </div>
+            </div>
+        </div>
+    </div>
 
-                <div class="row">
-                    <div class="mui-textfield">
-                        <%= form.text_field :stolen_zip, class: '', id: 'stolen_zip' %>
-                        <%= form.label :stolen_zip %>
+    <div class="form-section panel container">
+        <h3>Appearance</h3>
+
+        <div class="row">
+            <div class="col-md-4">
+                <div class="mui-select">
+                    <%= form.label :Primary_color %>
+                    <%= form.select :color_primary, [
+                    ['None', 'none'],
+                    ['Red','red'],
+                    ['Dark Red', 'dark red'],
+                    ['Light Red', 'light red'],
+                    ['Blue','blue'],
+                    ['Dark Blue','dark blue'],
+                    ['Light Blue','light blue'],
+                    ['Green','green'],
+                    ['Dark Green','dark green'],
+                    ['Light Green','light green'],
+                    ['Yellow','yellow'],
+                    ['Orange','orange'],
+                    ['White','white'],
+                    ['Black', 'black'],
+                    ['Grey','grey'],
+                    ['Purple','purple']] %>
+                </div>
+            </div>
+
+            <div class="col-md-4">
+                <div class="mui-select">
+                    <%= form.label :Secondary_color %>
+                    <%= form.select :color_secondary, [
+                    ['None', 'none'],
+                    ['Red','red'],
+                    ['Dark Red', 'dark red'],
+                    ['Light Red', 'light red'],
+                    ['Blue','blue'],
+                    ['Dark Blue','dark blue'],
+                    ['Light Blue','light blue'],
+                    ['Green','green'],
+                    ['Dark Green','dark green'],
+                    ['Light Green','light green'],
+                    ['Yellow','yellow'],
+                    ['Orange','orange'],
+                    ['White','white'],
+                    ['Black', 'black'],
+                    ['Grey','grey'],
+                    ['Purple','purple']] %>
+                </div>
+            </div>
+
+            <div class="col-md-4">
+                <div class="mui-select">
+                    <%= form.label :Tertiary_color %>
+                    <%= form.select :color_tertiary, [
+                    ['None', 'none'],
+                    ['Red','red'],
+                    ['Dark Red', 'dark red'],
+                    ['Light Red', 'light red'],
+                    ['Blue','blue'],
+                    ['Dark Blue','dark blue'],
+                    ['Light Blue','light blue'],
+                    ['Green','green'],
+                    ['Dark Green','dark green'],
+                    ['Light Green','light green'],
+                    ['Yellow','yellow'],
+                    ['Orange','orange'],
+                    ['White','white'],
+                    ['Black', 'black'],
+                    ['Grey','grey'],
+                    ['Purple','purple']] %>
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-12">
+                <div class="mui-textfield">
+                    <%= form.text_area :description, class: '', id: 'description' %>
+                    <%= form.label :description_and_cosmetic_details, class: '', for: 'description' %>
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-12">
+                <div class="mui-textfield">
+                    <%= form.label :photo %>
+                    <%= form.file_field :photo, class: 'mui-btn' %>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="form-section panel container">
+        <h3>Missing Status</h3>
+
+        <div class="row" id="stolen-section">
+            <div class="col-md-6" style="padding-left: 70px;">
+                <div class="mui-textfield">
+                    <div class="row mui-radio"
+                         style="position: absolute; top: 0; display: block; width: 100%; color: rgba(0,0,0,.54); font-size: 12px; font-weight: 400; line-height: 15px; overflow-x: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                        <%= form.radio_button(:is_stolen, true, {:class => "true_clicked" }) %>
+                        <%= form.label(:bike_true, "My bike was stolen") %>
+                    </div>
+                    <div class="row mui-radio"
+                         style="position: absolute; top: 0; display: block; width: 100%; color: rgba(0,0,0,.54); font-size: 12px; font-weight: 400; line-height: 15px; overflow-x: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                        <%= form.radio_button(:is_stolen, false, {:class => "false_clicked"}) %>
+                        <%= form.label(:bike_false, "My bike was not stolen", class: '', for: 'is_stolen') %>
                     </div>
                 </div>
+            </div>
 
-                <div class="row">
-                    <div class="mui-textfield">
-                        <%= form.text_field :stolen_date, class: '', id: 'stolen_date', placeholder: '01/01/16' %>
-                        <%= form.label :stolen_date %>
+            <div class="col-md-6">
+                <div class="stolen_form" style="display: none">
+
+                    <div class="row">
+                        <div class="mui-textfield">
+                            <%= form.text_field :stolen_zip, class: '', id: 'stolen_zip' %>
+                            <%= form.label :stolen_zip %>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="mui-textfield">
+                            <%= form.text_field :stolen_date, class: '', id: 'stolen_date', placeholder: '01/01/16' %>
+                            <%= form.label :stolen_date %>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/app/views/bike/index.html.erb
+++ b/app/views/bike/index.html.erb
@@ -1,8 +1,8 @@
 <div class="bikeForm container well">
 
-    <h1>Add a bike</h1>
-
     <%= form_for :bike do |form| %>
+
+    <h1>Add a bike</h1>
 
     <div class="row">
         <div class="col-md-6">
@@ -100,34 +100,65 @@
         </div>
     </div>
 
-    <br><br>
-    <%= form.radio_button(:is_stolen, true, {:class => "true_clicked"}) %>
-    <%= form.label(:bike_true, "My bike was stolen") %>
-    <%= form.radio_button(:is_stolen, false, {:class => "false_clicked"}) %>
-    <%= form.label(:bike_false, "My bike was not stolen") %>
-
-    <div class="stolen_form" style="display: none">
-        <br>
-        <%= form.label :stolen_zip %>
-        <br>
-        <%= form.text_field :stolen_zip %>
-        <br><br>
-        <%= form.label :stolen_date %>
-        <br>
-        <%= form.text_field :stolen_date %>
-        <br>
+    <div class="row">
+        <div class="col-md-12">
+            <div class="mui-textfield">
+                <%= form.label :photo %>
+                <%= form.file_field :photo, class: 'mui-btn' %>
+            </div>
+        </div>
     </div>
 
-    <br><br>
-    <%= form.label :photo %>
-    <%= form.file_field :photo %>
-
-    <div class="md-form">
-        <%= form.text_area :description, class: 'form-control', id: 'description' %>
-        <%= form.label :description, class: '', for: 'description' %>
+    <div class="row">
+        <div class="col-md-12">
+            <div class="mui-textfield">
+                <%= form.text_area :description, class: 'form-control', id: 'description', placeholder: 'Has a Georgetown Brewing Company sticker on downtube, scratch on front fork, pink tassles on handlebars. Was locked up at 3rd and University bike rack when Kryptonite U-lock was snipped between 1pm and 3pm.' %>
+                <%= form.label :description, class: '', for: 'description' %>
+            </div>
+        </div>
     </div>
-    <br><br>
-    <%= form.submit %>
+
+    <div class="row" id="stolen-section">
+        <div class="col-md-6" style="padding-left: 70px;">
+            <div class="mui-textfield">
+                <div class="row mui-radio" style="position: absolute; top: 0; display: block; width: 100%; color: rgba(0,0,0,.54); font-size: 12px; font-weight: 400; line-height: 15px; overflow-x: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                    <%= form.radio_button(:is_stolen, true, {:class => "true_clicked" }) %>
+                    <%= form.label(:bike_true, "My bike was stolen") %>
+                </div>
+                <div class="row mui-radio" style="position: absolute; top: 0; display: block; width: 100%; color: rgba(0,0,0,.54); font-size: 12px; font-weight: 400; line-height: 15px; overflow-x: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                    <%= form.radio_button(:is_stolen, false, {:class => "false_clicked"}) %>
+                    <%= form.label(:bike_false, "My bike was not stolen", class: '', for: 'is_stolen') %>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-6">
+            <div class="stolen_form" style="display: none">
+
+                <div class="row">
+                    <div class="mui-textfield">
+                        <%= form.text_field :stolen_zip, class: 'form-control', id: 'stolen_zip' %>
+                        <%= form.label :stolen_zip %>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="mui-textfield">
+                        <%= form.text_field :stolen_date, class: 'form-control', id: 'stolen_date', placeholder: '01/01/16' %>
+                        <%= form.label :stolen_date %>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+
+    </div>
+
+    <div class="row" style="text-align: center; padding-top: 50px;">
+        <%= form.submit 'Register', :class => 'mui-btn mui-btn--primary' %>
+    </div>
+
     <%end%>
+
 
 </div>

--- a/app/views/bike/index.html.erb
+++ b/app/views/bike/index.html.erb
@@ -4,79 +4,101 @@
 
     <%= form_for :bike do |form| %>
 
-    <div class="md-form">
-        <%= form.text_field :brand, class: 'form-control', id: 'brand' %>
-        <%= form.label :brand, class: '', for: 'brand' %>
+    <div class="row">
+        <div class="col-md-6">
+            <div class="mui-textfield">
+                <%= form.text_field :brand, class: 'form-control', id: 'brand' %>
+                <%= form.label :brand, class: '', for: 'brand' %>
+            </div>
+        </div>
+
+        <div class="col-md-6">
+            <div class="mui-textfield">
+                <%= form.text_field :model, class: 'form-control', id: 'model' %>
+                <%= form.label :model, class: '', for: 'model' %>
+            </div>
+        </div>
     </div>
 
-    <div class="md-form">
-        <%= form.text_field :model, class: 'form-control', id: 'model' %>
-        <%= form.label :model, class: '', for: 'model' %>
+    <div class="row">
+        <div class="col-md-12">
+            <div class="mui-textfield">
+                <%= form.text_field :serial_num, class: 'form-control', id: 'serial_num' %>
+                <%= form.label :serial_number, class: '', for: 'serial_num' %>
+            </div>
+        </div>
     </div>
 
-    <div class="md-form">
-        <%= form.text_field :serial_num, class: 'form-control', id: 'serial_num' %>
-        <%= form.label :serial_number, class: '', for: 'serial_num' %>
+    <div class="row">
+        <div class="col-md-4">
+            <div class="mui-select">
+                <%= form.label :Primary_color %>
+                <%= form.select :color_primary, [
+                ['None', 'none'],
+                ['Red','red'],
+                ['Dark Red', 'dark red'],
+                ['Light Red', 'light red'],
+                ['Blue','blue'],
+                ['Dark Blue','dark blue'],
+                ['Light Blue','light blue'],
+                ['Green','green'],
+                ['Dark Green','dark green'],
+                ['Light Green','light green'],
+                ['Yellow','yellow'],
+                ['Orange','orange'],
+                ['White','white'],
+                ['Black', 'black'],
+                ['Grey','grey'],
+                ['Purple','purple']] %>
+            </div>
+        </div>
+
+        <div class="col-md-4">
+            <div class="mui-select">
+                <%= form.label :Secondary_color %>
+                <%= form.select :color_secondary, [
+                ['None', 'none'],
+                ['Red','red'],
+                ['Dark Red', 'dark red'],
+                ['Light Red', 'light red'],
+                ['Blue','blue'],
+                ['Dark Blue','dark blue'],
+                ['Light Blue','light blue'],
+                ['Green','green'],
+                ['Dark Green','dark green'],
+                ['Light Green','light green'],
+                ['Yellow','yellow'],
+                ['Orange','orange'],
+                ['White','white'],
+                ['Black', 'black'],
+                ['Grey','grey'],
+                ['Purple','purple']] %>
+            </div>
+        </div>
+
+        <div class="col-md-4">
+            <div class="mui-select">
+                <%= form.label :Tertiary_color %>
+                <%= form.select :color_tertiary, [
+                ['None', 'none'],
+                ['Red','red'],
+                ['Dark Red', 'dark red'],
+                ['Light Red', 'light red'],
+                ['Blue','blue'],
+                ['Dark Blue','dark blue'],
+                ['Light Blue','light blue'],
+                ['Green','green'],
+                ['Dark Green','dark green'],
+                ['Light Green','light green'],
+                ['Yellow','yellow'],
+                ['Orange','orange'],
+                ['White','white'],
+                ['Black', 'black'],
+                ['Grey','grey'],
+                ['Purple','purple']] %>
+            </div>
+        </div>
     </div>
-
-    <br><br>
-    <%= form.label :Primarycolor %>
-    <%= form.select :color_primary, [['Red','red'],
-    ['Dark Red', 'dark red'],
-    ['Light Red', 'light red'],
-    ['Blue','blue'],
-    ['Dark Blue','dark blue'],
-    ['Light Blue','light blue'],
-    ['Green','green'],
-    ['Dark Green','dark green'],
-    ['Light Green','light green'],
-    ['Yellow','yellow'],
-    ['Orange','orange'],
-    ['White','white'],
-    ['Black', 'black'],
-    ['Grey','grey'],
-    ['Purple','purple']] %>
-
-
-
-    <br><br>
-    <%= form.label :Secondcolor %>
-    <%= form.select :color_secondary, [['Red','red'],
-    ['Dark Red', 'dark red'],
-    ['Light Red', 'light red'],
-    ['Blue','blue'],
-    ['Dark Blue','dark blue'],
-    ['Light Blue','light blue'],
-    ['Green','green'],
-    ['Dark Green','dark green'],
-    ['Light Green','light green'],
-    ['Yellow','yellow'],
-    ['Orange','orange'],
-    ['White','white'],
-    ['Black', 'black'],
-    ['Grey','grey'],
-    ['Purple','purple']] %>
-
-    <br><br>
-    <%= form.label :Thirdcolor %>
-    <%= form.select :color_tertiary, [['Red','red'],
-    ['Dark Red', 'dark red'],
-    ['Light Red', 'light red'],
-    ['Blue','blue'],
-    ['Dark Blue','dark blue'],
-    ['Light Blue','light blue'],
-    ['Green','green'],
-    ['Dark Green','dark green'],
-    ['Light Green','light green'],
-    ['Yellow','yellow'],
-    ['Orange','orange'],
-    ['White','white'],
-    ['Black', 'black'],
-    ['Grey','grey'],
-    ['Purple','purple']] %>
-
-
-
 
     <br><br>
     <%= form.radio_button(:is_stolen, true, {:class => "true_clicked"}) %>
@@ -104,7 +126,6 @@
         <%= form.text_area :description, class: 'form-control', id: 'description' %>
         <%= form.label :description, class: '', for: 'description' %>
     </div>
-
     <br><br>
     <%= form.submit %>
     <%end%>

--- a/app/views/bike/index.html.erb
+++ b/app/views/bike/index.html.erb
@@ -16,7 +16,7 @@
 
     <div class="md-form">
         <%= form.text_field :serial_num, class: 'form-control', id: 'serial_num' %>
-        <%= form.label :serial_num, class: '', for: 'serial_num' %>
+        <%= form.label :serial_number, class: '', for: 'serial_num' %>
     </div>
 
     <br><br>
@@ -100,10 +100,11 @@
     <%= form.label :photo %>
     <%= form.file_field :photo %>
 
-    <br><br>
-    <%= form.label :description %>
-    <br>
-    <%= form.text_area :description %>
+    <div class="md-form">
+        <%= form.text_area :description, class: 'form-control', id: 'description' %>
+        <%= form.label :description, class: '', for: 'description' %>
+    </div>
+
     <br><br>
     <%= form.submit %>
     <%end%>

--- a/app/views/partials/sitewide_assets/_cssheader.html.erb
+++ b/app/views/partials/sitewide_assets/_cssheader.html.erb
@@ -8,12 +8,12 @@
 <!-- Bootstrap latest compiled and minified CSS -->
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 
-<!-- Animation for bike and frontpage styles -->
-<link rel="stylesheet" type="text/css" href="css/bike.css">
-
 <!-- MUI Junk -->
 <link href="//cdn.muicss.com/mui-0.7.5/css/mui.min.css" rel="stylesheet" type="text/css" />
 <script src="//cdn.muicss.com/mui-0.7.5/js/mui.min.js"></script>
 
 <!-- Font Awesome -->
 <link rel="stylesheet" href="path/to/font-awesome/css/font-awesome.min.css">
+
+<!-- Animation for bike and frontpage styles -->
+<link rel="stylesheet" type="text/css" href="css/bike.css">

--- a/app/views/partials/sitewide_assets/_cssheader.html.erb
+++ b/app/views/partials/sitewide_assets/_cssheader.html.erb
@@ -4,7 +4,7 @@
  <link href='http://fonts.googleapis.com/css?family=Amatic+SC:400,700' rel='stylesheet' type='text/css'>
  <!-- Bootstrap latest compiled and minified CSS -->
  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
- <!-- Material Design library -->
- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.1.1/css/mdb.min.css">
+ <!-- Materialize Compiled and minified CSS -->
+ <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.7/css/materialize.min.css">
  <!-- Font Awesome -->
  <link rel="stylesheet" href="path/to/font-awesome/css/font-awesome.min.css">

--- a/app/views/partials/sitewide_assets/_cssheader.html.erb
+++ b/app/views/partials/sitewide_assets/_cssheader.html.erb
@@ -1,10 +1,19 @@
- <!-- Animation for bike and frontpage styles -->
- <link rel="stylesheet" type="text/css" href="css/bike.css">
- <!-- Font for front page banner -->
- <link href='http://fonts.googleapis.com/css?family=Amatic+SC:400,700' rel='stylesheet' type='text/css'>
- <!-- Bootstrap latest compiled and minified CSS -->
- <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
- <!-- Materialize Compiled and minified CSS -->
- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.7/css/materialize.min.css">
- <!-- Font Awesome -->
- <link rel="stylesheet" href="path/to/font-awesome/css/font-awesome.min.css">
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<!-- Font for front page banner -->
+<link href='http://fonts.googleapis.com/css?family=Amatic+SC:400,700' rel='stylesheet' type='text/css'>
+
+<!-- Bootstrap latest compiled and minified CSS -->
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+
+<!-- Animation for bike and frontpage styles -->
+<link rel="stylesheet" type="text/css" href="css/bike.css">
+
+<!-- MUI Junk -->
+<link href="//cdn.muicss.com/mui-0.7.5/css/mui.min.css" rel="stylesheet" type="text/css" />
+<script src="//cdn.muicss.com/mui-0.7.5/js/mui.min.js"></script>
+
+<!-- Font Awesome -->
+<link rel="stylesheet" href="path/to/font-awesome/css/font-awesome.min.css">

--- a/app/views/partials/sitewide_assets/_jslinks.html.erb
+++ b/app/views/partials/sitewide_assets/_jslinks.html.erb
@@ -7,8 +7,8 @@
 <!-- Bootstrap JS -->
 <script type="text/javascript" src='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js'></script>
 
-<!-- Materialize Compiled and minified JavaScript -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.7/js/materialize.min.js"></script>
+<!--&lt;!&ndash; Materialize Compiled and minified JavaScript &ndash;&gt;-->
+<!--<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.7/js/materialize.min.js"></script>-->
 
 <!-- Stuff for making the frontpage bike move. -->
 <script type="text/javascript">

--- a/app/views/partials/sitewide_assets/_jslinks.html.erb
+++ b/app/views/partials/sitewide_assets/_jslinks.html.erb
@@ -7,8 +7,8 @@
 <!-- Bootstrap JS -->
 <script type="text/javascript" src='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js'></script>
 
-<!-- Material Design junk -->
-<script src=" https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.1.1/js/mdb.min.js"></script>
+<!-- Materialize Compiled and minified JavaScript -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.7/js/materialize.min.js"></script>
 
 <!-- Stuff for making the frontpage bike move. -->
 <script type="text/javascript">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,30 +1,52 @@
-<!--<h1>Login</h1>-->
+<!--<div class="container well">-->
+    <!--<h1>Login</h1>-->
 
-<!--<%= form_for :user do |f| %>-->
-  <!--<%= f.email_field :email, placeholder: "Enter your email" %>-->
-  <!--<%= f.password_field :password, placeholder: "Enter your password" %>-->
-  <!--<%= f.submit "Login" %>-->
-<!--<% end %>-->
+    <!--<%= form_for :user do |form| %>-->
 
+    <!--<div class="md-form">-->
+        <!--<%= form.text_field :email, class: 'form-control', id: 'email' %>-->
+        <!--<%= form.label :email, class: '', for: 'email' %>-->
+    <!--</div>-->
 
-<div class="container well">
-    <h1>Login</h1>
+    <!--<div class="md-form">-->
+        <!--<%= form.password_field :password, class: 'form-control', id: 'password' %>-->
+        <!--<%= form.label :password, class: '', for: 'password' %>-->
+    <!--</div>-->
 
-    <%= form_for :user do |form| %>
+    <!--<div class="md-form">-->
+        <!--<%= form.submit 'LOG IN', :class => 'btn btn-primary' %>-->
+    <!--</div>-->
 
-    <div class="md-form">
-        <%= form.text_field :email, class: 'form-control', id: 'email' %>
-        <%= form.label :email, class: '', for: 'email' %>
+    <!--<%end%>-->
+<!--</div>-->
+
+<div class="container">
+
+    <%= form_for :bike do |form| %>
+
+    <div class="page-heading mui--text-light mui--text-display1">Log in</div>
+
+    <div class="form-section panel container">
+        <h3>fuck you buddy</h3>
+
+        <div class="row" style="text-align: left;">
+            <div class="col-md-6">
+                <div class="mui-textfield">
+                    <%= form.text_field :email, class: '', id: 'email' %>
+                    <%= form.label :email, class: '', for: 'email' %>
+                </div>
+            </div>
+
+            <div class="col-md-6">
+                <div class="mui-textfield">
+                    <%= form.password_field :password, class: '', id: 'password' %>
+                    <%= form.label :password, class: '', for: 'password' %>
+                </div>
+            </div>
+        </div>
+
     </div>
 
-    <div class="md-form">
-        <%= form.password_field :password, class: 'form-control', id: 'password' %>
-        <%= form.label :password, class: '', for: 'password' %>
-    </div>
-
-    <div class="md-form">
-        <%= form.submit 'LOG IN', :class => 'btn btn-primary' %>
-    </div>
-
+    <%= form.submit 'SIGN UP', :class => 'mui-btn mui-btn--primary' %>
     <%end%>
 </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,10 +1,13 @@
 <div class="container">
 
-    <%= form_for :bike do |form| %>
-
-    <div class="page-heading mui--text-light mui--text-display1">Log In, buddy</div>
+    <div class="page-heading mui--text-light mui--text-display1">
+        Log In
+    </div>
 
     <div class="form-section panel container" style="padding-top: 20px; text-align: left;">
+
+        <%= form_for :user do |form| %>
+
 
         <div class="row" style="text-align: left;">
             <div class="col-md-6">
@@ -24,6 +27,6 @@
 
     </div>
 
-    <%= form.submit 'SIGN UP', :class => 'mui-btn mui-btn--primary' %>
+    <%= form.submit 'LOG IN', :class => 'mui-btn mui-btn--primary' %>
     <%end%>
 </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,33 +1,10 @@
-<!--<div class="container well">-->
-    <!--<h1>Login</h1>-->
-
-    <!--<%= form_for :user do |form| %>-->
-
-    <!--<div class="md-form">-->
-        <!--<%= form.text_field :email, class: 'form-control', id: 'email' %>-->
-        <!--<%= form.label :email, class: '', for: 'email' %>-->
-    <!--</div>-->
-
-    <!--<div class="md-form">-->
-        <!--<%= form.password_field :password, class: 'form-control', id: 'password' %>-->
-        <!--<%= form.label :password, class: '', for: 'password' %>-->
-    <!--</div>-->
-
-    <!--<div class="md-form">-->
-        <!--<%= form.submit 'LOG IN', :class => 'btn btn-primary' %>-->
-    <!--</div>-->
-
-    <!--<%end%>-->
-<!--</div>-->
-
 <div class="container">
 
     <%= form_for :bike do |form| %>
 
-    <div class="page-heading mui--text-light mui--text-display1">Log in</div>
+    <div class="page-heading mui--text-light mui--text-display1">Log In, buddy</div>
 
-    <div class="form-section panel container">
-        <h3>fuck you buddy</h3>
+    <div class="form-section panel container" style="padding-top: 20px; text-align: left;">
 
         <div class="row" style="text-align: left;">
             <div class="col-md-6">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -25,8 +25,8 @@
             </div>
         </div>
 
+            <%= form.submit 'LOG IN', :class => 'mui-btn mui-btn--primary' %>
+        <%end%>
     </div>
 
-    <%= form.submit 'LOG IN', :class => 'mui-btn mui-btn--primary' %>
-    <%end%>
 </div>

--- a/app/views/user/index.html.erb
+++ b/app/views/user/index.html.erb
@@ -1,25 +1,42 @@
-<div class="container well" id="sign-up">
+<div class="container">
 
-    <h1><legend>Sign up</legend></h1>
+    <div class="page-heading mui--text-light mui--text-display1">
+        Sign up, buddy
+    </div>
 
-    <%= form_for :user do |form| %>
+    <div class="form-section panel container" style="padding-top: 20px; text-align: left;">
 
-        <div class="mui-textfield">
-            <%= form.text_field :name, class: 'form-control', id: 'name' %>
-            <%= form.label :name, class: '', for: 'name' %>
+        <%= form_for :user do |form| %>
+
+        <div class="row">
+            <div class="col-md-12">
+                <div class="mui-textfield">
+                    <%= form.text_field :name, class: 'form-control', id: 'name' %>
+                    <%= form.label :name, class: '', for: 'name' %>
+                </div>
+            </div>
         </div>
 
-        <div class="mui-textfield">
-            <%= form.text_field :email, class: 'form-control', id: 'email' %>
-            <%= form.label :email, class: '', for: 'email' %>
+        <div class="row">
+            <div class="col-md-12">
+                <div class="mui-textfield">
+                    <%= form.text_field :email, class: 'form-control', id: 'email' %>
+                    <%= form.label :email, class: '', for: 'email' %>
+                </div>
+            </div>
         </div>
 
-        <div class="mui-textfield">
-            <%= form.text_field :password, class: 'form-control', id: 'password' %>
-            <%= form.label :password, class: '', for: 'password' %>
+        <div class="row">
+            <div class="col-md-12">
+                <div class="mui-textfield">
+                    <%= form.text_field :password, class: 'form-control', id: 'password' %>
+                    <%= form.label :password, class: '', for: 'password' %>
+                </div>
+            </div>
         </div>
 
-        <%= form.submit 'SIGN UP', :class => 'mui-btn mui-btn--primary' %>
+    </div>
 
+    <%= form.submit 'SIGN UP', :class => 'mui-btn mui-btn--primary' %>
     <%end%>
 </div>

--- a/app/views/user/index.html.erb
+++ b/app/views/user/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
 
     <div class="page-heading mui--text-light mui--text-display1">
-        Sign up, buddy
+        Sign up
     </div>
 
     <div class="form-section panel container" style="padding-top: 20px; text-align: left;">
@@ -11,7 +11,7 @@
         <div class="row">
             <div class="col-md-12">
                 <div class="mui-textfield">
-                    <%= form.text_field :name, class: 'form-control', id: 'name' %>
+                    <%= form.text_field :name, class: '', id: 'name' %>
                     <%= form.label :name, class: '', for: 'name' %>
                 </div>
             </div>
@@ -20,7 +20,7 @@
         <div class="row">
             <div class="col-md-12">
                 <div class="mui-textfield">
-                    <%= form.text_field :email, class: 'form-control', id: 'email' %>
+                    <%= form.text_field :email, class: 'f', id: 'email' %>
                     <%= form.label :email, class: '', for: 'email' %>
                 </div>
             </div>
@@ -29,7 +29,7 @@
         <div class="row">
             <div class="col-md-12">
                 <div class="mui-textfield">
-                    <%= form.text_field :password, class: 'form-control', id: 'password' %>
+                    <%= form.password_field :password, class: '', id: 'password' %>
                     <%= form.label :password, class: '', for: 'password' %>
                 </div>
             </div>

--- a/app/views/user/index.html.erb
+++ b/app/views/user/index.html.erb
@@ -1,26 +1,25 @@
-<div class="container well">
-    <h1>Enter your info</h1>
+<div class="container well" id="sign-up">
+
+    <h1><legend>Sign up</legend></h1>
 
     <%= form_for :user do |form| %>
 
-        <div class="md-form">
+        <div class="mui-textfield">
             <%= form.text_field :name, class: 'form-control', id: 'name' %>
             <%= form.label :name, class: '', for: 'name' %>
         </div>
 
-        <div class="md-form">
+        <div class="mui-textfield">
             <%= form.text_field :email, class: 'form-control', id: 'email' %>
             <%= form.label :email, class: '', for: 'email' %>
         </div>
 
-        <div class="md-form">
+        <div class="mui-textfield">
             <%= form.text_field :password, class: 'form-control', id: 'password' %>
             <%= form.label :password, class: '', for: 'password' %>
         </div>
 
-        <div class="md-form">
-            <%= form.submit 'SIGN UP', :class => 'btn btn-primary' %>
-        </div>
+        <%= form.submit 'SIGN UP', :class => 'mui-btn mui-btn--primary' %>
 
     <%end%>
 </div>

--- a/app/views/user/index.html.erb
+++ b/app/views/user/index.html.erb
@@ -35,8 +35,7 @@
             </div>
         </div>
 
+        <%= form.submit 'SIGN UP', :class => 'mui-btn mui-btn--primary' %>
+        <%end%>
     </div>
-
-    <%= form.submit 'SIGN UP', :class => 'mui-btn mui-btn--primary' %>
-    <%end%>
 </div>

--- a/app/views/user/show.html.erb
+++ b/app/views/user/show.html.erb
@@ -7,8 +7,8 @@
 
         <hr>
 
-        <a class="btn btn-primary btn-sm" href='#'>Edit Info</a>
-        <a class="btn btn-primary btn-sm" href='/logout'>Log Out</a>
+        <a class="mui-btn mui-btn--primary mui-btn--small" href='#'>Edit Info</a>
+        <a class="mui-btn mui-btn--primary mui-btn--small" href='/logout'>Log Out</a>
     </div>
 
     <div class='col-md-1'></div>
@@ -20,7 +20,7 @@
 
         <% @bikes.each do |bike| %>
 
-        <div class="user-bikes">
+        <div class="mui-panel user-bikes">
             <div class="row">
 
                 <div class="col-md-6">
@@ -34,8 +34,8 @@
                     <h6><label>Is Missing: </label> <%= bike.is_stolen %></h6>
 
 
-                    <a class="btn btn-primary btn-sm" href='/bike/<%= bike.id %>/edit'>Edit</a>
-                    <%= link_to "Delete Bike", bike_path(bike), method: :delete, class: 'btn btn-danger btn-sm' %>
+                    <a class="mui-btn mui-btn--primary mui-btn--flat mui-btn--small" href='/bike/<%= bike.id %>/edit'>Edit</a>
+                    <%= link_to "Delete Bike", bike_path(bike), method: :delete, class: 'mui-btn mui-btn--danger mui-btn--flat mui-btn--small' %>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Figured I'd open a pull request now before this feature branch gets too out of hand. Here's what is happening here:

*MAJOR CHANGE: Added [Material UI](https://www.muicss.com/) framework/library to break out of Bootstrap-y looks. This can be seen in the partials/stylesheets/sitewide_assets/_cssheader as a two new links to a CDN for both the CSS and JS resources.
*Restyle the following forms: Login, Sign Up, Add Bike, Edit Bike. I haven't yet managed to style the file field for uploading Images, but still plan on it -- that default "Choose File" button looks straight outta Windows 98.
*Slight tweaking of the style of User Profile. Added different buttons for Edit/Delete bike as well as a different panel style. Also changed the buttons for Edit User and Logout.
